### PR TITLE
fix compatibility with > wazo 21.05

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -70,7 +70,7 @@ var print_backends = function(data) {
 var set_cookies = function(data) {
     session = { token: data['data']['token'],
                 uuid: data['data']['xivo_user_uuid'],
-                acls: data['data']['acls'],
+                acls: data['data']['acl'] || data['data']['acls'],
                 auth_id: data['data']['auth_id'],
                 expires: new Date(data['data']['expires_at']),
                 auth_host: auth.host,


### PR DESCRIPTION
reason: the key acls was deprecated and has been removed in 21.05